### PR TITLE
Quote paths to work with paths that have spaces

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,9 @@ resource "null_resource" "buildlambdazip" {
   triggers { key = "${uuid()}" }
   provisioner "local-exec" {
     command = <<EOF
-    mkdir -p ${path.module}/lambda && mkdir -p ${path.module}/tmp
-    cp ${path.module}/ebs_bckup/ebs_bckup.py ${path.module}/tmp/ebs_bckup.py
-    echo "${data.template_file.vars.rendered}" > ${path.module}/tmp/vars.ini
+    mkdir -p "${path.module}/lambda" && mkdir -p "${path.module}/tmp"
+    cp "${path.module}/ebs_bckup/ebs_bckup.py" "${path.module}/tmp/ebs_bckup.py"
+    echo "${data.template_file.vars.rendered}" > "${path.module}/tmp/vars.ini"
 EOF
   }
 }


### PR DESCRIPTION
When running from a file path containing spaces errors are generated, quoting the paths fixes this.

Fixes https://github.com/kgorskowski/ebs_bckup/issues/7